### PR TITLE
Improved merge implementation

### DIFF
--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -61,30 +61,3 @@ func testLocatorEqual(expected byte, loc locators.Locator) bool {
 	}
 	return (&testLocator{[]byte{expected}}).Equal(hash)
 }
-
-func Test_peersMerge(t *testing.T) {
-	var prs Peers
-	prs.peers = []*Peer{
-		testPeer(1, "1.1.1.1"),
-		testPeer(2, "1.1.1.2"),
-	}
-	update := []*Peer{
-		testPeer(2, "2.2.2.2"),
-		testPeer(3, "3.3.3.3"),
-	}
-	t.Run("Merge completed without error", func(t *testing.T) { assert.Nil(t, prs.merge(update)) })
-	t.Run("There are 3 peers after merge", func(t *testing.T) { assert.Equal(t, len(prs.peers), 3) })
-	var first, second, third *Peer
-	for _, p := range prs.peers {
-		if testLocatorEqual(1, p.Locator) { //nolint:gocritic
-			first = p
-		} else if testLocatorEqual(2, p.Locator) { //nolint:gocritic
-			second = p
-		} else if testLocatorEqual(3, p.Locator) { //nolint:gocritic
-			third = p
-		}
-	}
-	t.Run("First peer has `1.1.1.1` address", assertAddr(first.Addr, "1.1.1.1"))
-	t.Run("Second peer has `2.2.2.2` address", assertAddr(second.Addr, "2.2.2.2"))
-	t.Run("Third peer has `3.3.3.3` address", assertAddr(third.Addr, "3.3.3.3"))
-}

--- a/discovery/peers.go
+++ b/discovery/peers.go
@@ -1,0 +1,100 @@
+// MIT License. Copyright (c) 2020 CQFN
+// https://github.com/cqfn/degitx/blob/master/LICENSE
+
+package discovery
+
+import (
+	"context"
+
+	"cqfn.org/degitx/locators"
+	ma "github.com/multiformats/go-multiaddr"
+	mh "github.com/multiformats/go-multihash"
+)
+
+// Peers local storage
+type Peers struct {
+	peers   map[string]*Peer
+	updates chan *updateMsg
+}
+
+const chanSize = 16
+
+// NewPeers initialises and start queue for peers processing
+func NewPeers(ctx context.Context) *Peers {
+	p := new(Peers)
+	p.peers = make(map[string]*Peer)
+	p.updates = make(chan *updateMsg, chanSize)
+	go p.runLoop(ctx)
+	return p
+}
+
+func (p *Peers) runLoop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case upd := <-p.updates:
+			p.merge(upd)
+			if upd.done != nil {
+				close(upd.done)
+			}
+		}
+	}
+}
+
+// Peers slice
+func (p *Peers) Peers() []*Peer {
+	res := make([]*Peer, 0, len(p.peers))
+	for _, peer := range p.peers {
+		res = append(res, peer.Copy())
+	}
+	return res
+}
+
+// Update peers with new peer, notifies optional done channel on complete
+func (p *Peers) Update(peer *Peer, done chan struct{}) error {
+	hash, err := peer.Locator.Multihash()
+	if err != nil {
+		return err
+	}
+	upd := &updateMsg{
+		id:   hash.HexString(),
+		hash: hash,
+		addr: peer.Addr,
+		done: done,
+	}
+	p.updates <- upd
+	return nil
+}
+
+// Peer node
+type Peer struct {
+	Locator locators.Locator
+	Addr    ma.Multiaddr
+}
+
+// Copy peer to new structure
+func (p *Peer) Copy() *Peer {
+	cpy := new(Peer)
+	cpy.Addr = p.Addr
+	cpy.Locator = p.Locator
+	return cpy
+}
+
+type updateMsg struct {
+	id   string
+	hash mh.Multihash
+	addr ma.Multiaddr
+	done chan struct{}
+}
+
+func (p *Peers) merge(upd *updateMsg) {
+	if peer, found := p.peers[upd.id]; found {
+		peer.Addr = upd.addr
+	} else {
+		p.peers[upd.id] = &Peer{
+			Locator: locators.FromMultihash(upd.hash),
+			Addr:    upd.addr,
+		}
+	}
+}

--- a/discovery/peers_test.go
+++ b/discovery/peers_test.go
@@ -1,0 +1,49 @@
+// MIT License. Copyright (c) 2020 CQFN
+// https://github.com/cqfn/degitx/blob/master/LICENSE
+
+package discovery
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func blockingUpdate(prs *Peers, upd *Peer) error {
+	done := make(chan struct{})
+	if err := prs.Update(upd, done); err != nil {
+		return err
+	}
+	<-done
+	return nil
+}
+
+func Test_peersMerge(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	prs := NewPeers(ctx)
+	err := blockingUpdate(prs, testPeer(1, "1.1.1.1"))
+	assert.Nil(t, err, "updates 1 without error")
+	err = blockingUpdate(prs, testPeer(2, "1.1.1.2"))
+	assert.Nil(t, err, "updates 2 without error")
+	err = blockingUpdate(prs, testPeer(2, "2.2.2.2"))
+	assert.Nil(t, err, "updates 2 (new data) without error")
+	err = blockingUpdate(prs, testPeer(3, "3.3.3.3"))
+	assert.Nil(t, err, "updates 3 without error")
+
+	assert.Len(t, prs.peers, 3, "there are 3 peers after update")
+	var first, second, third *Peer
+	for _, p := range prs.Peers() {
+		if testLocatorEqual(1, p.Locator) { //nolint:gocritic
+			first = p
+		} else if testLocatorEqual(2, p.Locator) { //nolint:gocritic
+			second = p
+		} else if testLocatorEqual(3, p.Locator) { //nolint:gocritic
+			third = p
+		}
+	}
+	t.Run("First peer has `1.1.1.1` address", assertAddr(first.Addr, "1.1.1.1"))
+	t.Run("Second peer has `2.2.2.2` address", assertAddr(second.Addr, "2.2.2.2"))
+	t.Run("Third peer has `3.3.3.3` address", assertAddr(third.Addr, "3.3.3.3"))
+}

--- a/discovery/server_test.go
+++ b/discovery/server_test.go
@@ -22,8 +22,10 @@ func testLocString(d byte) []byte {
 
 func Test_ReceivePing(t *testing.T) {
 	svc := new(hostService)
-	svc.ctx = context.Background()
-	svc.peers = &Peers{make([]*Peer, 0)}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	svc.ctx = ctx
+	svc.peers = NewPeers(ctx)
 	coord := &pb.NodeCoord{
 		Address: "/ip4/127.0.0.1",
 		Locator: testLocString(1),

--- a/locators/locator.go
+++ b/locators/locator.go
@@ -82,3 +82,8 @@ func FromBytes(data []byte) (Locator, error) {
 	}
 	return &mhLocator{hash}, nil
 }
+
+// FromMultihash creates new locator from multihash
+func FromMultihash(hash mh.Multihash) Locator {
+	return &mhLocator{hash}
+}


### PR DESCRIPTION
#49 - improved merge implementation:
 - asynchronous single go-routine for peers update
 - using `map[string]Peer` instead of slice for indexing peers
