### PR TITLE
#52 Server info implemented

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,8 @@ builds:
       - windows
       - darwin
     main: ./cmd/node/main.go
+    ldflags:
+    - -s -w -X cqfn.org/degitx/version.version={{.Version}}
 archives:
   - replacements:
       darwin: Darwin

--- a/degitx.go
+++ b/degitx.go
@@ -10,8 +10,12 @@ import (
 	"net"
 
 	"cqfn.org/degitx/discovery"
+	"cqfn.org/degitx/gitlab/service/server"
 	"cqfn.org/degitx/locators"
+	"cqfn.org/degitx/logging"
 	"cqfn.org/degitx/proto/go/degitxpb"
+	"cqfn.org/degitx/version"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 )
@@ -26,6 +30,10 @@ func Start(ctx context.Context, node *locators.Node,
 	}
 
 	grpcServer := grpc.NewServer()
+	logger, err := logging.NewLogger("gRPC")
+	if err != nil {
+		return err
+	}
 
 	degitxpb.RegisterBlobServiceServer(grpcServer, &degitxpb.UnimplementedBlobServiceServer{})
 	degitxpb.RegisterCleanupServiceServer(grpcServer, &degitxpb.UnimplementedCleanupServiceServer{})
@@ -40,7 +48,7 @@ func Start(ctx context.Context, node *locators.Node,
 	degitxpb.RegisterWikiServiceServer(grpcServer, &degitxpb.UnimplementedWikiServiceServer{})
 	degitxpb.RegisterConflictsServiceServer(grpcServer, &degitxpb.UnimplementedConflictsServiceServer{})
 	degitxpb.RegisterRemoteServiceServer(grpcServer, &degitxpb.UnimplementedRemoteServiceServer{})
-	degitxpb.RegisterServerServiceServer(grpcServer, &degitxpb.UnimplementedServerServiceServer{})
+	degitxpb.RegisterServerServiceServer(grpcServer, server.NewServer(logger, version.GetVersion()))
 	degitxpb.RegisterObjectPoolServiceServer(grpcServer, &degitxpb.UnimplementedObjectPoolServiceServer{})
 	degitxpb.RegisterHookServiceServer(grpcServer, &degitxpb.UnimplementedHookServiceServer{})
 	degitxpb.RegisterInternalGitalyServer(grpcServer, &degitxpb.UnimplementedInternalGitalyServer{})

--- a/gitlab/service/server/info.go
+++ b/gitlab/service/server/info.go
@@ -1,0 +1,22 @@
+// MIT License. Copyright (c) 2020 CQFN
+// https://github.com/cqfn/degitx/blob/master/LICENSE
+
+package server
+
+import (
+	"cqfn.org/degitx/proto/go/degitxpb"
+
+	"golang.org/x/net/context"
+)
+
+func (server *server) ServerInfo(
+	context.Context,
+	*degitxpb.ServerInfoRequest,
+) (*degitxpb.ServerInfoResponse, error) {
+	server.log.Info("ServerInfo RPC was called")
+	return &degitxpb.ServerInfoResponse{
+		ServerVersion:   server.version,
+		GitVersion:      "not-implemented",
+		StorageStatuses: []*degitxpb.ServerInfoResponse_StorageStatus{},
+	}, nil
+}

--- a/gitlab/service/server/server.go
+++ b/gitlab/service/server/server.go
@@ -1,0 +1,37 @@
+// MIT License. Copyright (c) 2020 CQFN
+// https://github.com/cqfn/degitx/blob/master/LICENSE
+
+// Package server contains server for gRPC server service
+package server
+
+import (
+	"fmt"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"cqfn.org/degitx/logging"
+	"cqfn.org/degitx/proto/go/degitxpb"
+)
+
+type server struct {
+	version string
+	log     *logging.Logger
+}
+
+func NewServer(log *logging.Logger, degitxVersion string) degitxpb.ServerServiceServer {
+	return &server{
+		version: fmt.Sprintf("degitx-v%s (gitaly-v1.27.1)", degitxVersion),
+		log:     log,
+	}
+}
+
+// Doesn't exist in v1.27.1
+func (server *server) DiskStatistics(
+	context.Context,
+	*degitxpb.DiskStatisticsRequest,
+) (*degitxpb.DiskStatisticsResponse, error) {
+	server.log.Error("DiskStatistics RPC was called but doesn't exist in gitaly v1.27.1")
+	return nil, status.Errorf(codes.Unimplemented, "method DiskStatistics not implemented")
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/urfave/cli/v2 v2.2.0
 	go.uber.org/zap v1.16.0
+	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
 	google.golang.org/grpc v1.27.0
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/yaml.v2 v2.3.0

--- a/version/degitx_version.go
+++ b/version/degitx_version.go
@@ -1,0 +1,11 @@
+// MIT License. Copyright (c) 2020 CQFN
+// https://github.com/cqfn/degitx/blob/master/LICENSE
+
+// Package version provide information about degitx build.
+package version
+
+var version = "dev"
+
+func GetVersion() string {
+	return version
+}


### PR DESCRIPTION
#52 Server info implemented: service takes `server_version` from `goreleaser`. Other fields and methods of `ServerService` remain not implemented.