### PR TITLE
Implemented discovery registry over metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,6 @@ install-deps:
 
 # run golangci-lint
 lint:
-	golint .
-	golint ./discovery
-	golint ./locators
 	@golangci-lint --version
 	golangci-lint run
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ test: build
 	go test $(FLAGS) ./cmd/degitx
 	go test $(FLAGS) ./cmd/degitx-gitaly
 
-
 degitx: build proto
 	go build $(FLAGS) ./cmd/degitx
 
@@ -45,6 +44,9 @@ install-deps:
 
 # run golangci-lint
 lint:
+	golint .
+	golint ./discovery
+	golint ./locators
 	@golangci-lint --version
 	golangci-lint run
 

--- a/cmd/degitx/main.go
+++ b/cmd/degitx/main.go
@@ -102,7 +102,8 @@ func cmdRun(ctx *cli.Context) error {
 			addr, node, peers)
 		dps = append(dps, dsc)
 	}
-	dsc := discovery.NewDiscovery(peers, discovery.NewProviderChain(dps...))
+	dsc := discovery.NewDiscovery(peers, discovery.NewProviderChain(dps...),
+		new(discovery.NopRegistry))
 	node.Addr, err = ma.NewMultiaddr(ctx.String("gitaly-host"))
 	if err != nil {
 		return err

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -22,20 +22,22 @@ package discovery
 import (
 	"bytes"
 	"context"
+	"fmt"
 
 	mh "github.com/multiformats/go-multihash"
 )
 
-// Discovery protocol
+// Discovery protocol. It's provider and registry in one struct
 type Discovery struct {
 	peers *Peers
 	prov  Provider
+	reg   Registry
 }
 
 // NewDiscovery creates discovery protocol encapsulating
-// peers table and discovery providers
-func NewDiscovery(peers *Peers, prov Provider) *Discovery {
-	return &Discovery{peers, prov}
+// peers table, discovery providers and registries
+func NewDiscovery(peers *Peers, prov Provider, reg Registry) *Discovery {
+	return &Discovery{peers, prov, reg}
 }
 
 func (d *Discovery) Resolve(ctx context.Context,
@@ -50,4 +52,24 @@ func (d *Discovery) Resolve(ctx context.Context,
 		d.peers.update(p, nil)
 	}
 	return p, err
+}
+
+func (d *Discovery) Update(ctx context.Context, p *Peer) error {
+	done := make(chan struct{})
+	err := make(chan error)
+	d.peers.update(p, done)
+	go func() {
+		select {
+		case <-done:
+			err <- d.reg.Update(ctx, p)
+		case <-ctx.Done():
+			err <- ctx.Err()
+		}
+	}()
+	return <-err
+}
+
+func (d *Discovery) String() string {
+	return fmt.Sprintf("Discovery: provider=%s, registry=%s",
+		d.prov, d.reg)
 }

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -40,6 +40,7 @@ func NewDiscovery(peers *Peers, prov Provider, reg Registry) *Discovery {
 	return &Discovery{peers, prov, reg}
 }
 
+// Resolve a peer from local table or discovery provider
 func (d *Discovery) Resolve(ctx context.Context,
 	loc mh.Multihash) (*Peer, error) {
 	for _, p := range d.peers.Peers() {
@@ -54,6 +55,7 @@ func (d *Discovery) Resolve(ctx context.Context,
 	return p, err
 }
 
+// Update local peers table and registry with new peer
 func (d *Discovery) Update(ctx context.Context, p *Peer) error {
 	done := make(chan struct{})
 	err := make(chan error)

--- a/discovery/meta_provider.go
+++ b/discovery/meta_provider.go
@@ -23,13 +23,6 @@ const keyPrefix = "cqfn.org/degitx/discovery/node/"
 
 const resolveTimeout = 30 * time.Second
 
-// @todo #105:90min Implement discovery registration mechanism.
-//  There should be common interface to introduce a node to the network
-//  and register itself in storage. For MVP it should be registration
-//  in metadata key-value storage by updating network address of
-//  node locator. Keep in mind, that other discovery techicues could
-//  be used later.
-
 func (p *metaProvider) Resolve(ctx context.Context,
 	loc mh.Multihash) (*Peer, error) {
 	buf := bytes.NewBuffer([]byte(keyPrefix))

--- a/discovery/meta_provider.go
+++ b/discovery/meta_provider.go
@@ -23,6 +23,7 @@ const keyPrefix = "cqfn.org/degitx/discovery/node/"
 
 const resolveTimeout = 30 * time.Second
 
+// Resolve peer from metadata storage
 func (p *metaProvider) Resolve(ctx context.Context,
 	loc mh.Multihash) (*Peer, error) {
 	buf := bytes.NewBuffer([]byte(keyPrefix))

--- a/discovery/meta_registry.go
+++ b/discovery/meta_registry.go
@@ -15,6 +15,7 @@ type metaRegistry struct {
 	meta meta.Storage
 }
 
+// Update metadata storage with new peer
 func (r *metaRegistry) Update(ctx context.Context, p *Peer) error {
 	cto, cancel := context.WithTimeout(ctx, resolveTimeout)
 	defer cancel()

--- a/discovery/meta_registry.go
+++ b/discovery/meta_registry.go
@@ -1,0 +1,41 @@
+// MIT License. Copyright (c) 2020 CQFN
+// https://github.com/cqfn/degitx/blob/master/LICENSE
+
+package discovery
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"cqfn.org/degitx/meta"
+)
+
+type metaRegistry struct {
+	meta meta.Storage
+}
+
+func (r *metaRegistry) Update(ctx context.Context, p *Peer) error {
+	cto, cancel := context.WithTimeout(ctx, resolveTimeout)
+	defer cancel()
+	bin, err := p.Locator.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	buf := bytes.NewBuffer([]byte(keyPrefix))
+	if _, err := buf.Write([]byte(p.Locator.ID.HexString())); err != nil {
+		// byte.Buffer doesn't return errors on write
+		panic(err)
+	}
+	rsp := <-r.meta.Set(cto, buf.String(), meta.Data(bin))
+	return rsp.Error
+}
+
+func (r *metaRegistry) String() string {
+	return fmt.Sprintf("MetaData discovery registry: %s", r.meta)
+}
+
+// NewMetaRegistry creates new discovery registry over metadata storage
+func NewMetaRegistry(meta meta.Storage) Registry {
+	return &metaRegistry{meta}
+}

--- a/discovery/meta_registry_test.go
+++ b/discovery/meta_registry_test.go
@@ -1,0 +1,32 @@
+// MIT License. Copyright (c) 2020 CQFN
+// https://github.com/cqfn/degitx/blob/master/LICENSE
+
+package discovery
+
+import (
+	"context"
+	"testing"
+
+	"cqfn.org/degitx/meta"
+	matcher "github.com/g4s8/go-matchers"
+)
+
+func Test_Resolve(t *testing.T) {
+	assert := matcher.Assert(t)
+	st := meta.NewInMemStorage()
+	peer := testPeer(1, "1.1.1.1")
+	bin, err := peer.Locator.MarshalBinary()
+	if err != nil {
+		panic(err)
+	}
+	if err := meta.SetSync(st,
+		"cqfn.org/degitx/discovery/node/"+peer.Locator.ID.HexString(),
+		meta.Data(bin)); err != nil {
+		panic(err)
+	}
+	pr := NewMetaProvider(st)
+	resolve, err := pr.Resolve(context.Background(), peer.Locator.ID)
+	assert.That("Resolved without errors", err, matcher.Nil())
+	assert.That("Resolved correct peer", resolve.Addr.Bytes(),
+		matcher.Eq(peer.Addr.Bytes()))
+}

--- a/discovery/net.go
+++ b/discovery/net.go
@@ -9,11 +9,13 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
+// MaNetworkAddr implements NetworkAddress interface from Multiaddr
 type MaNetworkAddr struct {
 	net  string
 	addr string
 }
 
+// Network name string, e.g. ipv4 or ipv6
 func (n *MaNetworkAddr) Network() string { //nolint:dupl // linter mistake
 	return n.net
 }

--- a/discovery/peers.go
+++ b/discovery/peers.go
@@ -61,7 +61,7 @@ func (e *errPeerNotFound) Error() string {
 }
 
 // Address of peer node
-func (p *Peers) Address(hash mh.Multihash, ctx context.Context) (ma.Multiaddr, error) {
+func (p *Peers) Address(hash mh.Multihash) (ma.Multiaddr, error) {
 	if peer, found := p.peers[hash.HexString()]; found {
 		return peer.Addr, nil
 	}
@@ -90,6 +90,7 @@ func (p *Peer) String() string {
 	return fmt.Sprintf("Peer(`%s`, `%s`)", p.Locator, p.Addr)
 }
 
+// GoString returns debug information for `%#v` format option
 func (p *Peer) GoString() string {
 	return fmt.Sprintf("Peer(Locator(%#v), Addr(%#v))",
 		p.Locator, p.Addr)

--- a/discovery/provider.go
+++ b/discovery/provider.go
@@ -38,6 +38,7 @@ func (e *ErrFailedToResolve) Error() string {
 		e.loc.HexString(), e.p)
 }
 
+// Unwrap origin error
 func (e *ErrFailedToResolve) Unwrap() error {
 	return e.origin
 }
@@ -61,6 +62,7 @@ type Registry interface {
 // NopRegistry does nothing on update
 type NopRegistry struct{}
 
+// Update nothing
 func (r *NopRegistry) Update(context.Context, *Peer) error {
 	return nil
 }

--- a/discovery/provider.go
+++ b/discovery/provider.go
@@ -44,11 +44,29 @@ func (e *ErrFailedToResolve) Unwrap() error {
 
 // Provider of peer nodes addresses
 type Provider interface {
+	fmt.Stringer
+
 	// Resolve peer by locator hash
 	Resolve(context.Context, mh.Multihash) (*Peer, error)
+}
 
-	// String representation
-	String() string
+// Registry of discovery peers
+type Registry interface {
+	fmt.Stringer
+
+	// Update discovery registry with new peer coordinates
+	Update(context.Context, *Peer) error
+}
+
+// NopRegistry does nothing on update
+type NopRegistry struct{}
+
+func (r *NopRegistry) Update(context.Context, *Peer) error {
+	return nil
+}
+
+func (r *NopRegistry) String() string {
+	return "NopRegistry"
 }
 
 type pChain struct {

--- a/locators/encoding.go
+++ b/locators/encoding.go
@@ -17,8 +17,7 @@ var version = [...]byte{0x00, 0x01}
 
 var byteOrder = binary.BigEndian //nolint:gochecknoglobals //package private constant
 
-// Binary encoding implementation of BinaryMarshaler and BinaryUnmarshaler interfaces
-
+// MarshalBinary is a binary encoding implementation
 func (n *Node) MarshalBinary() ([]byte, error) {
 	out := bundle.NewOut(byteOrder)
 	out.PutBytes(version[:])
@@ -36,6 +35,7 @@ func (e *errUnsupportedVersion) Error() string {
 	return fmt.Sprintf("Unsupported version `%s`", e.version)
 }
 
+// UnmarshalBinary is a binary decoding implementation
 func (n *Node) UnmarshalBinary(data []byte) error {
 	inp := bundle.NewInput(byteOrder)
 	if err := inp.UnmarshalBinary(data); err != nil {

--- a/locators/locator.go
+++ b/locators/locator.go
@@ -28,6 +28,7 @@ func (n *Node) String() string {
 	return fmt.Sprintf("Node(`%s`)", n.ID.HexString())
 }
 
+// GoString returns debug information for `%#v` format option
 func (n *Node) GoString() string {
 	return fmt.Sprintf("Node(ID(%#v), PubKey(%#v), Addr(%#v))",
 		n.ID, n.PubKey, n.Addr)


### PR DESCRIPTION
[#124] - implemented discovery registry over metadata
 - Added new interface `Registry` for discovery package
 - Updated `Discovery` struct to include registry
 - Added implementation of `Registry` over metadata
 - Added a test for meta implementation
 - Removed todo