### PR TITLE
Gitlab commit protocol: transaction timeout info

### DIFF
--- a/reports/gitlab-commit-protocol/gitlab-commit-protocol.tex
+++ b/reports/gitlab-commit-protocol/gitlab-commit-protocol.tex
@@ -167,7 +167,13 @@ communicates with Praefect node).
 The timeout used for all transactional actions like voting and stopping of transactions.
  The reasons of setting of this long timeout you can find 
 In \emph{\href{https://gitlab.com/gitlab-org/gitaly/-/blob/master/internal/gitaly/transaction/manager.go\#L21}{ source code comments}}. 
-In other words It shouldn't normally be hit, but if it is hit then it indicates a real problem. 
+In other words It shouldn't normally be hit, but if it is hit then it indicates that Praefect still waiting to the quorum reaching. 
+
+We assumed that there might be inconsistency in the situation with concurrent transaction when the Praefect 
+increments the generation of the primary node in the database. But due to the timeout on voting client, 
+the primary node did not receive a response from the Praefect and did not update its state. 
+Up to date secondaries are updated according this scenario, and have a latest generation in database table. 
+
 For gitaly clients it means that it can be waiting around for up to 5 minutes while the transaction 
 is completing if in case votes are missing to reach the quorum.
 

--- a/reports/gitlab-commit-protocol/gitlab-commit-protocol.tex
+++ b/reports/gitlab-commit-protocol/gitlab-commit-protocol.tex
@@ -159,8 +159,29 @@ If it set to `false`:
 TODO: To unite this section with Mutator RPC handling strategy.
 
 \section{Termination protocol}
+\subsection{Transaction timeout}
+In \emph{\href{https://gitlab.com/gitlab-org/gitaly/-/tags/v14.0.0-rc1}{ current}} 
+Gitaly version there is 5 minutes transaction timeout that is set on transaction 
+context when voting client on gitaly node votes on transaction (the voting client 
+communicates with Praefect node).
+The timeout used for all transactional actions like voting and stopping of transactions.
+ The reasons of setting of this long timeout you can find 
+In \emph{\href{https://gitlab.com/gitlab-org/gitaly/-/blob/master/internal/gitaly/transaction/manager.go\#L21}{ source code comments}}. 
+In other words It shouldn't normally be hit, but if it is hit then it indicates a real problem. 
+For gitaly clients it means that it can be waiting around for up to 5 minutes while the transaction 
+is completing if in case votes are missing to reach the quorum.
 
-TODO: what is the termination strategy to finish the transaction.
+There no any other timeouts on Praefect node or reference transaction hook side. 
+Hook will be waiting the any end scenario of transaction. They are :
+
+\begin{itemize}
+\item Transaction commited.
+\item Transaction stopped indicates a transaction was gracefully stopped. 
+This only happens in case the transaction was terminated because of an external condition, e.g. access checks or hooks rejected a change.
+\item Transaction aborted indicates a transaction was aborted, either because it timed out or because the vote failed to reach quorum.
+\item Invalid transaction state.
+\end{itemize}
+
 
 \section{Misc}
 \todo{to avoid this section (move facts to another section if it is possible)}


### PR DESCRIPTION
For: https://github.com/cqfn/degitx/issues/179. Added gitaly transaction timeout and failure scenarios info.
